### PR TITLE
feat: 画像から店舗特定時に確認メッセージで保存前に確認を求める

### DIFF
--- a/lib/handlePlaceConfirmPostback.ts
+++ b/lib/handlePlaceConfirmPostback.ts
@@ -1,0 +1,50 @@
+import * as admin from 'firebase-admin';
+import { PostbackEvent } from '@line/bot-sdk';
+import { saveMapLink } from './saveMapLink';
+import { sendReplyMessage } from './sendReplyMessage';
+
+const db = admin.firestore();
+
+export const handlePlaceConfirmPostback = async (
+  event: PostbackEvent,
+  action: string,
+  pendingId: string
+) => {
+  const replyToken = event.replyToken;
+
+  try {
+    const docRef = db.collection('pendingPlaces').doc(pendingId);
+    const doc = await docRef.get();
+
+    if (!doc.exists) {
+      await sendReplyMessage(replyToken, 'この確認は期限切れです。もう一度画像を送信してください。');
+      return;
+    }
+
+    const data = doc.data()!;
+
+    if (action === 'confirmPlace') {
+      await saveMapLink({
+        userId: data.userId,
+        groupId: data.groupId,
+        link: data.link,
+        placeDetails: data.placeDetails,
+        originalImageUrl: data.originalImageUrl,
+        displayName: data.displayName,
+        userPictureUrl: data.userPictureUrl,
+        groupName: data.groupName,
+        members: data.members,
+        groupPictureUrl: data.groupPictureUrl,
+      });
+
+      await docRef.delete();
+      await sendReplyMessage(replyToken, `「${data.placeDetails.name}」を保存しました！`);
+    } else if (action === 'cancelPlace') {
+      await docRef.delete();
+      await sendReplyMessage(replyToken, '保存をキャンセルしました。');
+    }
+  } catch (error) {
+    console.error('Error in handlePlaceConfirmPostback:', error);
+    await sendReplyMessage(replyToken, '処理中にエラーが発生しました。');
+  }
+};

--- a/lib/handlePostbackEvent.ts
+++ b/lib/handlePostbackEvent.ts
@@ -1,10 +1,20 @@
 import { PostbackEvent } from '@line/bot-sdk';
 import { sendReplyMessage } from './sendReplyMessage';
 import { handleUserPeriodPostback } from './handleUserPeriodPostback';
+import { handlePlaceConfirmPostback } from './handlePlaceConfirmPostback';
 
 // 型ガードを使用して inputOption プロパティが存在するか確認する
 const hasInputOption = (postback: any): postback is { inputOption: string } => {
   return 'inputOption' in postback;
+};
+
+const parsePostbackData = (data: string): Record<string, string> => {
+  const params: Record<string, string> = {};
+  data.split('&').forEach((pair) => {
+    const [key, value] = pair.split('=');
+    if (key && value) params[key] = value;
+  });
+  return params;
 };
 
 export const handlePostbackEvent = async (event: PostbackEvent) => {
@@ -15,6 +25,14 @@ export const handlePostbackEvent = async (event: PostbackEvent) => {
       return;
     } else if (data.startsWith('action=set')) {
       await handleUserPeriodPostback(event);
+      return;
+    } else if (data.startsWith('action=confirmPlace') || data.startsWith('action=cancelPlace')) {
+      const params = parsePostbackData(data);
+      const action = params.action;
+      const pendingId = params.pendingId;
+      if (action && pendingId) {
+        await handlePlaceConfirmPostback(event, action, pendingId);
+      }
       return;
     }
   } catch (error) {

--- a/lib/saveImageAsPlace.ts
+++ b/lib/saveImageAsPlace.ts
@@ -1,3 +1,4 @@
+import * as admin from 'firebase-admin';
 import { client } from './init/line';
 import { analyzeImageForPlace } from './analyzeImage';
 import { searchPlaceByText, PlaceDetails } from './googleMaps';
@@ -6,6 +7,8 @@ import { getCurrentUser } from './User/getCurrentUser';
 import { getJoinGroupInfo } from './Group/getJoinGroupInfo';
 import { saveImageBufferToStorage } from './Storage/GoogleMapPhotoUrl';
 import { SaveMapLinkParams } from '@/types/Link';
+
+const db = admin.firestore();
 
 type SaveImageAsPlaceParams = {
   messageId: string;
@@ -16,6 +19,7 @@ type SaveImageAsPlaceParams = {
 type SaveImageAsPlaceResult = {
   success: boolean;
   placeName?: string;
+  pendingId?: string;
   imageSaved?: boolean;
   error?: string;
 };
@@ -50,7 +54,7 @@ export async function saveImageAsPlace(
     }
 
     if (!analysis.placeName) {
-      // 店舗特定できなかった場合でも画像付きLinkを保存
+      // 店舗特定できなかった場合は画像付きLinkを即保存（確認不要）
       const saveParams: SaveMapLinkParams = {
         userId,
         groupId: groupId || '',
@@ -89,23 +93,31 @@ export async function saveImageAsPlace(
       placeDetails.name + ' ' + placeDetails.address
     )}`;
 
-    // 8. Firestoreに保存
-    const saveMapLinkParams: SaveMapLinkParams = {
+    // 8. pendingPlacesに一時保存（確認待ち）
+    const pendingData = {
       userId,
       groupId: groupId || '',
       link: mapsUrl,
-      placeDetails,
+      placeDetails: {
+        name: placeDetails.name,
+        address: placeDetails.address,
+        photoUrl: placeDetails.photoUrl,
+        latitude: placeDetails.latitude,
+        longitude: placeDetails.longitude,
+      },
       originalImageUrl,
       displayName: currentUser?.displayName || '',
       userPictureUrl: currentUser?.pictureUrl || '',
       groupName: groupData?.groupName || '',
       members: groupData?.members || [],
       groupPictureUrl: groupData?.pictureUrl || '',
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
     };
 
-    await saveMapLink(saveMapLinkParams);
+    const docRef = await db.collection('pendingPlaces').add(pendingData);
+    console.log('Pending place saved with ID:', docRef.id);
 
-    return { success: true, placeName: placeDetails.name, imageSaved: true };
+    return { success: true, placeName: placeDetails.name, pendingId: docRef.id, imageSaved: true };
   } catch (error) {
     console.error('Error in saveImageAsPlace:', error);
     return {

--- a/pages/api/webhook.ts
+++ b/pages/api/webhook.ts
@@ -245,11 +245,27 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
             groupId: groupId || undefined,
           });
 
-          if (result.success) {
-            await sendReplyMessage(
-              replyToken,
-              `画像から「${result.placeName}」を特定し、保存しました！`
-            );
+          if (result.success && result.pendingId) {
+            await sendReplyMessage(replyToken, {
+              type: 'template',
+              altText: `「${result.placeName}」で合っていますか？`,
+              template: {
+                type: 'confirm',
+                text: `画像から「${result.placeName}」を検出しました。この店舗を保存しますか？`,
+                actions: [
+                  {
+                    type: 'postback',
+                    label: 'はい',
+                    data: `action=confirmPlace&pendingId=${result.pendingId}`,
+                  },
+                  {
+                    type: 'postback',
+                    label: 'いいえ',
+                    data: `action=cancelPlace&pendingId=${result.pendingId}`,
+                  },
+                ],
+              },
+            });
           } else if (result.error === 'place_not_identified') {
             if (result.imageSaved) {
               await sendReplyMessage(


### PR DESCRIPTION
## Summary

LINE Botに画像を送信した際、店舗を特定した後に即座に保存するのではなく、Confirm Templateで「この店舗を保存しますか？」と確認メッセージを送信し、ユーザーの承認を得てから保存する機能を追加。Xのスクリーンショットなど複数店舗が含まれる画像での誤認識を防止する。

## Related Issue

Closes #

※Issue番号を確認して記入してください

## Changes

- **`lib/handlePlaceConfirmPostback.ts`** (新規): `confirmPlace`/`cancelPlace` postback処理。`pendingPlaces`からデータ取得→`saveMapLink()`で`Links`に保存、またはキャンセル時に削除
- **`lib/handlePostbackEvent.ts`**: `confirmPlace`/`cancelPlace` postbackデータの分岐を追加。`parsePostbackData()`ヘルパー関数を追加
- **`lib/saveImageAsPlace.ts`**: 店舗特定成功時に`Links`への即時保存をやめ、Firebase Admin SDKで`pendingPlaces`コレクションに一時保存し`pendingId`を返却するように変更
- **`pages/api/webhook.ts`**: 店舗特定成功時にLINE Confirm Template（「はい」/「いいえ」ボタン）を送信するように変更

## Test Plan

- [ ] LINE Botに店舗写真を送信し、確認メッセージ（Confirm Template）が返ること
- [ ] 「はい」をタップ → Firestoreの`Links`に保存され、「保存しました！」メッセージが返ること
- [ ] 「いいえ」をタップ → `pendingPlaces`が削除され、「キャンセルしました。」メッセージが返ること
- [ ] 店舗特定できない画像を送信 → 従来通り画像付きLinkが即保存されること
- [ ] `pnpm build` が成功すること

## Screenshots

N/A（LINE Bot上でのConfirm Template表示確認が必要）

## Additional Notes

- Firestoreに`pendingPlaces`コレクションが新規作成されます（確認待ちデータの一時保存用）
- `pendingPlaces`はFirebase Admin SDK経由で操作（サーバーサイド処理のため）
- 現時点では`pendingPlaces`のTTL/自動削除は未実装。将来的にCloud Functionsでの定期削除を検討